### PR TITLE
Removed DNSCastroSegmentedControlDelegate, used UIControl's target/actio...

### DIFF
--- a/DNSCastroSegmentedControl.xcodeproj/project.pbxproj
+++ b/DNSCastroSegmentedControl.xcodeproj/project.pbxproj
@@ -358,6 +358,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = DNSCastroSegmentedControl/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -368,6 +369,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = DNSCastroSegmentedControl/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -426,6 +428,7 @@
 				9B7821BA19DF9D8700C340C7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		9B7821BB19DF9D8700C340C7 /* Build configuration list for PBXNativeTarget "DNSCastroSegmentedControlTests" */ = {
 			isa = XCConfigurationList;
@@ -434,6 +437,7 @@
 				9B7821BD19DF9D8700C340C7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/DNSCastroSegmentedControl/Base.lproj/Main.storyboard
+++ b/DNSCastroSegmentedControl/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
     </dependencies>
@@ -13,32 +13,44 @@
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="ovI-wb-jw2" customClass="DNSCastroSegmentedControl">
-                                <rect key="frame" x="40" y="60" width="520" height="40"/>
+                                <rect key="frame" x="40" y="88" width="240" height="40"/>
                                 <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <connections>
-                                    <outlet property="delegate" destination="vXZ-lx-hvc" id="uLO-Ln-NWy"/>
+                                    <action selector="DNSCastroSegmentedControlChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="SlJ-uE-ST3"/>
                                 </connections>
                             </view>
                             <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="XHm-9W-22v" customClass="DNSCastroSegmentedControl">
-                                <rect key="frame" x="40" y="140" width="520" height="40"/>
+                                <rect key="frame" x="40" y="168" width="240" height="40"/>
                                 <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <connections>
-                                    <outlet property="delegate" destination="vXZ-lx-hvc" id="rMu-Sy-bOM"/>
+                                    <action selector="DNSCastroSegmentedControlChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="hWS-qZ-oIb"/>
                                 </connections>
                             </view>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="27t-dN-biq">
+                                <rect key="frame" x="99" y="20" width="123" height="29"/>
+                                <segments>
+                                    <segment title="First"/>
+                                    <segment title="Second"/>
+                                </segments>
+                                <connections>
+                                    <action selector="standardSegmentedControlChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="P42-v8-a9c"/>
+                                </connections>
+                            </segmentedControl>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="XHm-9W-22v" secondAttribute="trailing" constant="40" id="4le-Ud-K0s"/>
                             <constraint firstAttribute="trailing" secondItem="ovI-wb-jw2" secondAttribute="trailing" constant="40" id="9Wu-6r-EUg"/>
-                            <constraint firstItem="ovI-wb-jw2" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="40" id="EJz-hh-gN4"/>
                             <constraint firstItem="ovI-wb-jw2" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" constant="40" id="Ks2-ZK-gsx"/>
+                            <constraint firstItem="27t-dN-biq" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" id="aLq-dN-WFv"/>
                             <constraint firstItem="XHm-9W-22v" firstAttribute="top" secondItem="ovI-wb-jw2" secondAttribute="bottom" constant="40" id="f3C-fx-OzS"/>
+                            <constraint firstItem="ovI-wb-jw2" firstAttribute="top" secondItem="27t-dN-biq" secondAttribute="bottom" constant="40" id="hZ5-LF-bmt"/>
                             <constraint firstItem="XHm-9W-22v" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" constant="40" id="izC-OW-Q5Y"/>
+                            <constraint firstAttribute="centerX" secondItem="27t-dN-biq" secondAttribute="centerX" id="yoP-dt-XcW"/>
                         </constraints>
                     </view>
                     <connections>
@@ -51,4 +63,9 @@
             <point key="canvasLocation" x="596" y="162"/>
         </scene>
     </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination"/>
+    </simulatedMetricsContainer>
 </document>

--- a/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.h
+++ b/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.h
@@ -10,28 +10,13 @@
 
 @class DNSCastroSegmentedControl;
 
-@protocol DNSCastroSegmentedControlDelegate <NSObject>
-@required
-/**
- *  Fires when the selection index of the control changes.
- *
- *  @param control       The control which has changed.
- *  @param selectedIndex The newly selected index;  
- */
-- (void)segmentedControl:(DNSCastroSegmentedControl *)control didChangeToSelectedIndex:(NSInteger)selectedIndex;
-
-@end
-
 @interface DNSCastroSegmentedControl : UIControl
-
-///A delegate to notify of any choice changes.
-@property (nonatomic, weak) IBOutlet id<DNSCastroSegmentedControlDelegate> delegate;
 
 ///An array of the choices for the user. Should be NSString/AttributedString or UIImage.
 @property (nonatomic) NSArray *choices;
 
 ///The current selected index. Zero-indexed. 
-@property (nonatomic) NSInteger selectedIndex;
+@property (nonatomic) NSInteger selectedSegmentIndex;
 
 ///Will set a font to be used for all labels. If nil, the default system font will be used.
 @property (nonatomic) UIFont *labelFont;
@@ -48,6 +33,6 @@
  *  @param selectedIndex The index you wish to switch the control to
  *  @param animated      YES if you want this transition to be animated, NO if not.
  */
-- (void)setSelectedIndex:(NSInteger)selectedIndex animated:(BOOL)animated;
+- (void)setSelectedSegmentIndex:(NSInteger)selectedSegmentIndex animated:(BOOL)animated;
 
 @end

--- a/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.m
+++ b/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.m
@@ -40,7 +40,7 @@ static CGFloat DeselectedAlpha = 0.4;
         [self setupSectionViews];
         [self setupSelectionView];
         [self roundAllTheThings];
-        [self setSelectedIndex:self.selectedIndex animated:NO];
+        [self setSelectedSegmentIndex:self.selectedSegmentIndex animated:NO];
     }
 }
 
@@ -334,11 +334,11 @@ static CGFloat DeselectedAlpha = 0.4;
     }
 }
 
-- (void)setSelectedIndex:(NSInteger)selectedIndex
+- (void)setSelectedSegmentIndex:(NSInteger)selectedSegmentIndex
 {
-    if (_selectedIndex != selectedIndex) {
-        _selectedIndex = selectedIndex;
-        [self.delegate segmentedControl:self didChangeToSelectedIndex:selectedIndex];
+    if (_selectedSegmentIndex != selectedSegmentIndex) {
+        _selectedSegmentIndex = selectedSegmentIndex;
+        [self sendActionsForControlEvents:UIControlEventValueChanged];
     }
 }
 
@@ -383,8 +383,8 @@ static CGFloat DeselectedAlpha = 0.4;
     //Figure out where we're at.
     CGFloat section = self.initialTouchPoint.x / [self pointsPerSection];
     NSInteger roundedSection = floorf(section);
-    if (self.selectedIndex != roundedSection) {
-        [self setSelectedIndex:roundedSection animated:YES];
+    if (self.selectedSegmentIndex != roundedSection) {
+        [self setSelectedSegmentIndex:roundedSection animated:YES];
         [UIView animateWithDuration:AnimationDuration
                               delay:0
                             options:UIViewAnimationOptionCurveEaseOut
@@ -425,7 +425,7 @@ static CGFloat DeselectedAlpha = 0.4;
     CGFloat section = constantVSMax / [self pointsPerSection];
     NSInteger roundedSection = roundf(section);
     
-    [self setSelectedIndex:roundedSection animated:YES];
+    [self setSelectedSegmentIndex:roundedSection animated:YES];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
@@ -458,7 +458,7 @@ static CGFloat DeselectedAlpha = 0.4;
 
 - (void)snapToCurrentSection:(BOOL)isEmbiggened;
 {
-    CGFloat fullMove = self.selectedIndex * [self pointsPerSection];
+    CGFloat fullMove = self.selectedSegmentIndex * [self pointsPerSection];
     
     if (!isEmbiggened) {
         fullMove += SelectionViewPadding;
@@ -468,14 +468,14 @@ static CGFloat DeselectedAlpha = 0.4;
     [self layoutIfNeeded];
 }
 
-- (void)setSelectedIndex:(NSInteger)selectedIndex animated:(BOOL)animated
+- (void)setSelectedSegmentIndex:(NSInteger)selectedSegmentIndex animated:(BOOL)animated
 {
-    NSInteger previousSelectedIndex = _selectedIndex;
+    NSInteger previousSelectedSegmentIndex = _selectedSegmentIndex;
     if (!animated) {
-        self.selectedIndex = selectedIndex;
+        self.selectedSegmentIndex = selectedSegmentIndex;
         for (NSInteger i = 0; i < self.sectionViews.count; i++) {
             UIView *currentView = self.sectionViews[i];
-            if (i == selectedIndex) {
+            if (i == selectedSegmentIndex) {
                 currentView.alpha = SelectedAlpha;
             } else {
                 currentView.alpha = DeselectedAlpha;
@@ -486,10 +486,10 @@ static CGFloat DeselectedAlpha = 0.4;
         return;
     } //else, animate!
     
-    if (self.selectedIndex != selectedIndex) {
-        self.selectedIndex = selectedIndex;
-        UIView *wasHighlighted = self.sectionViews[previousSelectedIndex];
-        UIView *nowHighlighted = self.sectionViews[selectedIndex];
+    if (self.selectedSegmentIndex != selectedSegmentIndex) {
+        self.selectedSegmentIndex = selectedSegmentIndex;
+        UIView *wasHighlighted = self.sectionViews[previousSelectedSegmentIndex];
+        UIView *nowHighlighted = self.sectionViews[selectedSegmentIndex];
         [UIView animateWithDuration:AnimationDuration
                               delay:0
                             options:UIViewAnimationOptionCurveLinear //Crossfade

--- a/DNSCastroSegmentedControl/ViewController.m
+++ b/DNSCastroSegmentedControl/ViewController.m
@@ -10,7 +10,7 @@
 
 #import "DNSCastroSegmentedControl.h"
 
-@interface ViewController () <DNSCastroSegmentedControlDelegate>
+@interface ViewController ()
 @property (nonatomic, weak) IBOutlet DNSCastroSegmentedControl *segmentedControl;
 @property (nonatomic, weak) IBOutlet DNSCastroSegmentedControl *stairsSegmentedControl;
 @property (nonatomic) DNSCastroSegmentedControl *programmaticSegmentedControl;
@@ -25,7 +25,7 @@
     
     self.segmentedControl.choices = @[@"one", @"two", @"three", @"four"];
     self.segmentedControl.labelFont = [UIFont fontWithName:@"AmericanTypewriter" size:17];
-    self.segmentedControl.selectedIndex = 2;
+    self.segmentedControl.selectedSegmentIndex = 2;
     self.segmentedControl.tintColor = [UIColor orangeColor];
     self.segmentedControl.choiceColor = [UIColor whiteColor];
     self.segmentedControl.selectionViewColor = [UIColor greenColor];
@@ -50,7 +50,6 @@
         self.programmaticSegmentedControl = [[DNSCastroSegmentedControl alloc] init];
         self.programmaticSegmentedControl.translatesAutoresizingMaskIntoConstraints = NO;
         self.programmaticSegmentedControl.backgroundColor = self.stairsSegmentedControl.backgroundColor;
-        self.programmaticSegmentedControl.delegate = self;
         [self.view addSubview:self.programmaticSegmentedControl];
         
         //Pin to bottom of the stairs SC
@@ -83,7 +82,9 @@
         self.programmaticSegmentedControl.choices = @[@"Programmatic", @"Springs/Struts", @"Autolayout"];
         self.programmaticSegmentedControl.labelFont = [UIFont fontWithName:@"AppleSDGothicNeo-Medium" size:14];
         self.programmaticSegmentedControl.choiceColor = [UIColor orangeColor];
-        self.programmaticSegmentedControl.selectedIndex = 1;
+        self.programmaticSegmentedControl.selectedSegmentIndex = 1;
+        
+        [self.programmaticSegmentedControl addTarget:self action:@selector(DNSCastroSegmentedControlChanged:) forControlEvents:UIControlEventValueChanged];
         
         //Uncomment to move automatically after a delay
 //        [self performSelector:@selector(setProgrammaticIndex)
@@ -94,23 +95,25 @@
 
 - (void)setProgrammaticIndex
 {
-    [self.programmaticSegmentedControl setSelectedIndex:2 animated:YES];
+    [self.programmaticSegmentedControl setSelectedSegmentIndex:2 animated:YES];
 }
 
-#pragma mark - DNSCastroSegmentedControlDelegate
+- (IBAction)standardSegmentedControlChanged:(UISegmentedControl *)sender {
+    NSLog(@"%s Standard segmented control change to index %@",__PRETTY_FUNCTION__,@(sender.selectedSegmentIndex));
+}
 
-- (void)segmentedControl:(DNSCastroSegmentedControl *)control didChangeToSelectedIndex:(NSInteger)selectedIndex
+- (IBAction)DNSCastroSegmentedControlChanged:(DNSCastroSegmentedControl *)sender
 {
     NSString *controlName = nil;
-    if (control == self.segmentedControl) {
+    if (sender == self.segmentedControl) {
         controlName = @"First Segmented Control";
-    } else if (control == self.stairsSegmentedControl) {
+    } else if (sender == self.stairsSegmentedControl) {
         controlName = @"Stairs Segmented Control";
-    } else if (control == self.programmaticSegmentedControl) {
+    } else if (sender == self.programmaticSegmentedControl) {
         controlName = @"Programmatic Segmented Control";
     }
     
-    NSLog(@"Control %@ change to index %@", controlName, @(selectedIndex));
+    NSLog(@"Control %@ change to index %@", controlName, @(sender.selectedSegmentIndex));
 }
 
 @end


### PR DESCRIPTION
...n architecture instead.

As DNSCastroSegmentedControl will be used as a UISegmentedControl substitute, I think that it could be better to make it use the same target/action mechanism that the rest of the UIControls instead of a custom protocol/delegate pair.
