### PR TITLE
Sizes based on largest label/image

### DIFF
--- a/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.m
+++ b/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.m
@@ -8,10 +8,12 @@
 
 #import "DNSCastroSegmentedControl.h"
 
-static CGFloat SelectionViewPadding = 3;
+static CGFloat TextPadding = 10.0f;
+static CGFloat SelectionViewPadding = 3.0f;
+static CGFloat VerticalPadding = 3.0f;
 static NSTimeInterval AnimationDuration = 0.2;
 
-static CGFloat SelectedAlpha = 1;
+static CGFloat SelectedAlpha = 1.0f;
 static CGFloat DeselectedAlpha = 0.4;
 
 @interface DNSCastroSegmentedControl()
@@ -78,10 +80,10 @@ static CGFloat DeselectedAlpha = 0.4;
         NSString *viewName = [NSString stringWithFormat:@"view%@", @(i)];
         
         //Pin width to percentage
-        [self pinViewToWidth:view withPadding:0];
+        [self pinViewToWidth:view withPadding:0.0f];
         
         //Pin to top and bottom
-        [self pinViewToTopAndBottom:view withPadding:SelectionViewPadding];
+        [self pinViewToTopAndBottom:view withPadding:VerticalPadding];
         
         //Add to autolayout string to allow pinning next to each other.
         [autolayoutString appendFormat:@"[%@]", viewName];
@@ -111,7 +113,7 @@ static CGFloat DeselectedAlpha = 0.4;
         
     [self addSubview:self.selectionView];
     [self pinViewToWidth:self.selectionView withPadding:SelectionViewPadding * 2];
-    [self pinViewToTopAndBottom:self.selectionView withPadding:SelectionViewPadding];
+    [self pinViewToTopAndBottom:self.selectionView withPadding:VerticalPadding];
     
     self.selectionLeftConstraint = [NSLayoutConstraint constraintWithItem:self.selectionView
                                                                 attribute:NSLayoutAttributeLeft
@@ -119,7 +121,7 @@ static CGFloat DeselectedAlpha = 0.4;
                                                                    toItem:self
                                                                 attribute:NSLayoutAttributeLeft
                                                                multiplier:1
-                                                                 constant:SelectionViewPadding];
+                                                                 constant:-SelectionViewPadding];
     [self addConstraint:self.selectionLeftConstraint];
 }
 
@@ -132,13 +134,21 @@ static CGFloat DeselectedAlpha = 0.4;
 
 - (void)pinViewToWidth:(UIView *)view withPadding:(CGFloat)padding
 {
+    CGFloat maxWidth = 0.0f;
+    for (id choice in self.choices) {
+        UIView *view = [self viewForChoice:choice];
+        [view sizeToFit];
+        CGFloat viewWidth = CGRectGetWidth(view.bounds) + TextPadding * 2.0f;
+        maxWidth = (viewWidth > maxWidth) ? viewWidth : maxWidth;
+    }
+    
     [self addConstraint:[NSLayoutConstraint constraintWithItem:view
                                                      attribute:NSLayoutAttributeWidth
                                                      relatedBy:NSLayoutRelationEqual
-                                                        toItem:self
-                                                     attribute:NSLayoutAttributeWidth
-                                                    multiplier:[self sectionPercentage]
-                                                      constant:-padding]];
+                                                        toItem:nil
+                                                     attribute:NSLayoutAttributeNotAnAttribute
+                                                    multiplier:1.0f
+                                                      constant:maxWidth - padding]];
 }
 
 - (void)pinViewToTopAndBottom:(UIView *)view withPadding:(CGFloat)padding

--- a/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.m
+++ b/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.m
@@ -10,7 +10,6 @@
 
 static CGFloat TextPadding = 10.0f;
 static CGFloat SelectionViewPadding = 3.0f;
-static CGFloat VerticalPadding = 3.0f;
 static NSTimeInterval AnimationDuration = 0.2;
 
 static CGFloat SelectedAlpha = 1.0f;
@@ -83,7 +82,7 @@ static CGFloat DeselectedAlpha = 0.4;
         [self pinViewToWidth:view withPadding:0.0f];
         
         //Pin to top and bottom
-        [self pinViewToTopAndBottom:view withPadding:VerticalPadding];
+        [self pinViewToTopAndBottom:view withPadding:SelectionViewPadding];
         
         //Add to autolayout string to allow pinning next to each other.
         [autolayoutString appendFormat:@"[%@]", viewName];
@@ -113,7 +112,7 @@ static CGFloat DeselectedAlpha = 0.4;
         
     [self addSubview:self.selectionView];
     [self pinViewToWidth:self.selectionView withPadding:SelectionViewPadding * 2];
-    [self pinViewToTopAndBottom:self.selectionView withPadding:VerticalPadding];
+    [self pinViewToTopAndBottom:self.selectionView withPadding:SelectionViewPadding];
     
     self.selectionLeftConstraint = [NSLayoutConstraint constraintWithItem:self.selectionView
                                                                 attribute:NSLayoutAttributeLeft


### PR DESCRIPTION
I noticed that the control was placing each image/label and then choosing the size of the selection based on a the quotient of number of views and control width. 

Instead I figured what the largest size image/label is and base the creation off of that instead.