### PR TITLE
Use animated property setter in touch cancellation method

### DIFF
--- a/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.m
+++ b/DNSCastroSegmentedControl/Library/DNSCastroSegmentedControl.m
@@ -518,7 +518,7 @@ static CGFloat DefaultHeight = 40;
     [super touchesCancelled:touches withEvent:event];
     
     //Reset the selected segment index to what it was initially.
-    self.selectedSegmentIndex = self.valueAtStartOfTouches;
+    [self setSelectedSegmentIndex:self.valueAtStartOfTouches animated:YES];
     
     [self touchesEndedOrCancelled];
 }


### PR DESCRIPTION
Thanks for taking care of all those issues. Here's a new one (and a PR to resolve it).

**Reproduction steps:**

1. Start dragging from one segment to another.
2. Cancel the touches, for example by putting the segmented control in a table view and scrolling vertically.

**Expected behavior:**

I expect:

- `selectionView` to revert to its original position
- `selectionView.alpha` to revert to its original value

**Actual behavior:**

`selectionView` reverts to its original position properly, but `selectionView.alpha` remains unchanged.

**Notes:**

I was able to resolve this by using `setSelectedSegmentIndex:animated:` instead of the normal setter.

```
- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
{
    [super touchesCancelled:touches withEvent:event];
    
    //Reset the selected segment index to what it was initially.
    [self setSelectedSegmentIndex:self.valueAtStartOfTouches animated:YES];
    
    [self touchesEndedOrCancelled];
}
```

It might make sense for the non-animated `setSelectedSegmentIndex:` method to adjust the alpha as well. (I think both methods should have the same effect aside from whether that effect is animated.)

Here's before the change:

![before-change](https://cloud.githubusercontent.com/assets/789577/8025030/f5732a02-0d0d-11e5-83ca-11f14587a3a5.gif)

And after:

![after-change](https://cloud.githubusercontent.com/assets/789577/8025032/f9e8fd96-0d0d-11e5-8479-592649486b8d.gif)
